### PR TITLE
synced with main and fixed chatlist screen name display

### DIFF
--- a/src/main/java/data_access/SwipesListDataAccessObject.java
+++ b/src/main/java/data_access/SwipesListDataAccessObject.java
@@ -85,9 +85,8 @@ public class SwipesListDataAccessObject {
         return new ArrayList<>(); // Return an empty list if no data is found
     }
 
-
     /**
-     * Generate a swiping list for a specific user, ranked by compatibility
+     * Generate a swiping list for a specific user, ranked by compatibility.
      * @param username The username of the user
      * @return A list of users matching the preferred criteria, ranked by compatibility
      */

--- a/src/main/java/view/ListChatView.java
+++ b/src/main/java/view/ListChatView.java
@@ -141,10 +141,10 @@ public class ListChatView extends JPanel implements ActionListener, PropertyChan
                 for (ChatChannel channel: channels) {
                     String channelUser = "";
                     if (channel.getUser1Id().equals(state.getUsername())) {
-                        channelUser = channel.getUser1Id();
+                        channelUser = channel.getUser2Id();
                     }
                     else {
-                        channelUser = channel.getUser2Id();
+                        channelUser = channel.getUser1Id();
                     }
                     System.out.println(channel.getChannelURL());
                     System.out.println(channel.getLastMessage());


### PR DESCRIPTION
1. The chat list screen now correctly displays the name of the user you're chatting with for each chat.
